### PR TITLE
Fix visibility check on map view. Fixes #463

### DIFF
--- a/src/view.map.js
+++ b/src/view.map.js
@@ -53,7 +53,7 @@ my.Map = Backbone.View.extend({
 
   initialize: function(options) {
     var self = this;
-    this.visible = true;
+    this.visible = this.$el.is(':visible');
     this.mapReady = false;
     // this will be the Leaflet L.Map object (setup below)
     this.map = null;


### PR DESCRIPTION
The following check was failing on the first load, so autozoom didn't
work:

https://github.com/okfn/recline/blob/3f4a30e054652d06b92cfe372ce66c8b5c79d4ca/src/view.map.js#L232