### PR TITLE
Sanitize header name on SlickGrid view. Fixes #465

### DIFF
--- a/src/view.slickgrid.js
+++ b/src/view.slickgrid.js
@@ -160,10 +160,15 @@ my.SlickGrid = Backbone.View.extend({
       })
     }
 
+    function sanitizeFieldName(name) {
+      var sanitized = $(name).text();
+      return (name !== sanitized && sanitized !== '') ? sanitized : name;
+    }
+
     _.each(this.model.fields.toJSON(),function(field){
       var column = {
         id: field.id,
-        name: field.label,
+        name: sanitizeFieldName(field.label),
         field: field.id,
         sortable: true,
         minWidth: 80,


### PR DESCRIPTION
SlickGrid will use `$.html`[1] to render the header cell contents.

This means that if you are loading an external dodgy CSV like the
following one, scripts will be evaluated:

```
field1,field2<script>alert(123)</script>,field3
data1,data2,data3
data1,data2,data3
```
This fix sanitizes the label when initializing SlickGrid removing all
that isn't text.

[1] https://github.com/mleibman/SlickGrid/blob/e6e2f88f832742c44e0fabf1f3864e5176386033/slick.grid.js#L563