### PR TITLE
[#465] Sanitize header name on SlickGrid view

### DIFF
--- a/src/view.slickgrid.js
+++ b/src/view.slickgrid.js
@@ -161,13 +161,7 @@ my.SlickGrid = Backbone.View.extend({
     }
 
     function sanitizeFieldName(name) {
-      var sanitized;
-      try{
-        sanitized = $(name).text();
-      } catch(e){
-        sanitized = '';
-      }
-      return (name !== sanitized && sanitized !== '') ? sanitized : name;
+      return $('<div>').text(name).html();
     }
 
     _.each(this.model.fields.toJSON(),function(field){


### PR DESCRIPTION
Change logic of sanitizing. Previously either original value
or content of element with matching selector was used as column
header.

After this change original value with applied encoding of
html entities will be used