### PR TITLE
Fix the underscore's template usage.

### DIFF
--- a/src/view.flot.js
+++ b/src/view.flot.js
@@ -123,7 +123,8 @@ my.Flot = Backbone.View.extend({
           y = item.datapoint[0].toFixed(2);
         }
 
-        var content = _.template('<%= group %> = <%= x %>, <%= series %> = <%= y %>', {
+        var template = _.template('<%= group %> = <%= x %>, <%= series %> = <%= y %>');
+        var content = template({
           group: this.state.attributes.group,
           x: this._xaxisLabel(x),
           series: item.series.label,


### PR DESCRIPTION
The current code leads to this result : 

![screen png](https://cloud.githubusercontent.com/assets/2534060/18446039/93de283c-794a-11e6-9785-471108180890.jpg)

This PR fixs the underscore's template usage according to official docs.