### PR TITLE
Fixes _setupMap reference of undefined class property

### DIFF
--- a/src/view.map.js
+++ b/src/view.map.js
@@ -53,6 +53,7 @@ my.Map = Backbone.View.extend({
 
   initialize: function(options) {
     var self = this;
+    this.options = options;
     this.visible = this.$el.is(':visible');
     this.mapReady = false;
     // this will be the Leaflet L.Map object (setup below)


### PR DESCRIPTION
`view.map.js` 

```
_setupMap: function(){
    var self = this;
    this.map = new L.Map(this.$map.get(0));
    var mapUrl = this.options.mapTilesURL || 'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png';
```

that piece of code above was referencing an undefined `options` class property. 